### PR TITLE
Ability to get parent function by address

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ BinAssistMCP is a powerful bridge between Binary Ninja and Large Language Models
 
 - **MCP 2025-11-25 Compliant**: Full support for tool annotations, resources, and prompts
 - **Dual Transport Support**: SSE (Server-Sent Events) and Streamable HTTP transports
-- **39 Consolidated Tools**: Streamlined Binary Ninja API wrapper with unified tool design
+- **40 Consolidated Tools**: Streamlined Binary Ninja API wrapper with unified tool design
 - **8 MCP Resources**: Browsable, cacheable binary metadata
 - **7 Guided Prompts**: Pre-built workflows for common reverse engineering tasks
 - **Multi-Binary Sessions**: Concurrent analysis of multiple binaries with intelligent context management
@@ -34,7 +34,7 @@ BinAssistMCP is a powerful bridge between Binary Ninja and Large Language Models
 ```
 src/binassist_mcp/
 ├── server.py        # FastMCP server - SSE/Streamable HTTP transport, tool registration
-├── tools.py         # Binary Ninja API wrapper - 39 MCP tools
+├── tools.py         # Binary Ninja API wrapper - 40 MCP tools
 ├── plugin.py        # Binary Ninja plugin integration
 ├── context.py       # Thread-safe multi-binary session management
 ├── config.py        # Pydantic configuration with Binary Ninja settings
@@ -50,9 +50,9 @@ __init__.py          # Plugin entry point (root level)
 
 ---
 
-## Tools (39 Total)
+## Tools (40 Total)
 
-BinAssistMCP provides 39 tools organized into functional categories. Tools include MCP annotations (`readOnlyHint`, `idempotentHint`) to help clients make informed decisions.
+BinAssistMCP provides 40 tools organized into functional categories. Tools include MCP annotations (`readOnlyHint`, `idempotentHint`) to help clients make informed decisions.
 
 ### Binary Management
 | Tool | Description |
@@ -95,6 +95,7 @@ BinAssistMCP provides 39 tools organized into functional categories. Tools inclu
 | Tool | Description |
 |------|-------------|
 | `get_functions` | List all functions with metadata (paginated) |
+| `get_parent_function` | Get the function containing a given address |
 | `search_functions_by_name` | Find functions by name pattern |
 | `get_functions_advanced` | Advanced filtering by size, complexity, parameters |
 | `search_functions_advanced` | Multi-target search (name, comments, calls, variables) |

--- a/src/binassist_mcp/server.py
+++ b/src/binassist_mcp/server.py
@@ -583,6 +583,22 @@ class BinAssistMCPServer:
             return tools.get_functions()
 
         @mcp.tool(annotations=READ_ONLY_ANNOTATIONS)
+        def get_parent_function(filename: str, address: str, ctx: Context) -> dict:
+            """Get the function containing the given address
+
+            Args:
+                filename: Name of the binary file
+                address: Address in hex format (e.g., '0x401000')
+
+            Returns:
+                Dictionary with parent function name and start address
+            """
+            context_manager: BinAssistMCPBinaryContextManager = ctx.request_context.lifespan_context
+            binary_view = context_manager.get_binary(filename)
+            tools = BinAssistMCPTools(binary_view)
+            return tools.get_parent_function(address)
+
+        @mcp.tool(annotations=READ_ONLY_ANNOTATIONS)
         def search_functions_by_name(filename: str, search_term: str, ctx: Context) -> list:
             """Search functions by name substring
 

--- a/src/binassist_mcp/tools.py
+++ b/src/binassist_mcp/tools.py
@@ -454,7 +454,37 @@ class BinAssistMCPTools:
                 "basic_block_count": len(list(func.basic_blocks))
             })
         return functions
-        
+
+    @handle_exceptions
+    @require_binja
+    def get_parent_function(self, address: str) -> Dict[str, Any]:
+        """Get the function containing the given address
+
+        Args:
+            address: Address in hex format (e.g., '0x401000')
+
+
+        Returns:
+            Dictionary with parent function name and start address
+
+        Raises:
+            ValueError: If address is invalid or no function contains it
+        """
+        addr = self._resolve_symbol(address)
+        if addr is None:
+            raise ValueError(f"Invalid address: {address}")
+
+        funcs = self.bv.get_functions_containing(addr)
+        if not funcs:
+            raise ValueError(f"No function found containing address {hex(addr)}")
+
+        func = funcs[0]
+        return {
+            "name": func.name,
+            "address": hex(func.start),
+            "queried_address": hex(addr)
+        }
+
     @handle_exceptions
     @require_binja
     def search_functions_by_name(self, search_term: str) -> List[Dict[str, Any]]:


### PR DESCRIPTION
During analysis of tracebacks and xrefs it often required to get the address of function that containing given address.
Right now mcp clients are trying to do some crazy things with calculating possible function address.

I've added a new tool to get parent function for address, but I'm not sure that it is the best implementation, probably we can just improve `get_current_function` tool by adding an option parameter `address` to save number of tools provided by server